### PR TITLE
Hide tooltips on mobile devices

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -111,6 +111,12 @@
   opacity: 1;
 }
 
+@media (max-width: 768px) { /* Target mobile devices */
+  .map-tooltip, .tooltip-text {
+    display: none;
+  }
+}
+
 #not-found {
   justify-self: center;
   margin-top: 20%;


### PR DESCRIPTION
Mobile has no hover functionality, so tooltips add UI clutter